### PR TITLE
Feature/mssql integrated security

### DIFF
--- a/NapDatabaseExport/DatabaseProvider.cs
+++ b/NapDatabaseExport/DatabaseProvider.cs
@@ -37,9 +37,19 @@ namespace NapDatabaseExport
             get { return false; }
         }
 
+        public virtual bool RequiresUser
+        {
+            get { return UsesUser; }
+        }
+
         public string User { get; set; }
 
         public virtual bool UsesPassword
+        {
+            get { return false; }
+        }
+
+        public virtual bool RequiresPassword
         {
             get { return false; }
         }

--- a/NapDatabaseExport/MSSQLServerProvider.cs
+++ b/NapDatabaseExport/MSSQLServerProvider.cs
@@ -23,9 +23,19 @@ namespace NapDatabaseExport
             get { return true; }
         }
 
+        public override bool RequiresUser
+        {
+            get { return false; }
+        }
+
         public override bool UsesPassword
         {
             get { return true; }
+        }
+
+        public override bool RequiresPassword
+        {
+            get { return false; }
         }
 
         public override bool UsesDatabase
@@ -39,11 +49,18 @@ namespace NapDatabaseExport
             if (!string.IsNullOrEmpty (Server))
                 connectionString.DataSource = Server;
 
-            if (!string.IsNullOrEmpty (User))
+            if (!string.IsNullOrEmpty(User))
+            {
                 connectionString.UserID = User;
 
-            if (!string.IsNullOrEmpty (Password))
-                connectionString.Password = Password;
+                if (!string.IsNullOrEmpty(Password))
+                    connectionString.Password = Password;
+            }
+            else
+            {
+                connectionString.IntegratedSecurity = true;
+            }
+
 
             if (!string.IsNullOrEmpty (Database))
                 connectionString.InitialCatalog = Database;
@@ -95,7 +112,7 @@ namespace NapDatabaseExport
 
         public override bool TryConnect ()
         {
-            if (string.IsNullOrWhiteSpace (Server) || string.IsNullOrWhiteSpace (User))
+            if (string.IsNullOrWhiteSpace (Server))
                 throw new Exception ("The connection parameters are not properly set.");
 
             SqlConnection conn = null;
@@ -112,7 +129,7 @@ namespace NapDatabaseExport
         {
             var tables = new List<string> ();
 
-            using (var dr = ExecuteReader ("SELECT name FROM sys.databases"))
+            using (var dr = ExecuteReader ("SELECT name FROM sys.databases WHERE database_id > 4 ORDER BY name"))
                 while (dr.Read ())
                     tables.Add (dr.GetString (0));
 
@@ -123,7 +140,7 @@ namespace NapDatabaseExport
         {
             var tables = new List<string> ();
 
-            using (var dr = ExecuteReader (string.Format ("select name from [{0}].[sys].sysobjects where xtype = 'U'", Database)))
+            using (var dr = ExecuteReader (string.Format ("SELECT name FROM [{0}].dbo.sysobjects WHERE xtype = 'U' ORDER BY name", Database)))
                 while (dr.Read ())
                     tables.Add (dr.GetString (0));
 

--- a/NapDatabaseExport/MSSQLServerProvider.cs
+++ b/NapDatabaseExport/MSSQLServerProvider.cs
@@ -49,15 +49,13 @@ namespace NapDatabaseExport
             if (!string.IsNullOrEmpty (Server))
                 connectionString.DataSource = Server;
 
-            if (!string.IsNullOrEmpty (User))
-            {
+            if (!string.IsNullOrEmpty (User)) {
                 connectionString.UserID = User;
 
                 if (!string.IsNullOrEmpty (Password))
                     connectionString.Password = Password;
             }
-            else
-            {
+            else {
                 connectionString.IntegratedSecurity = true;
             }
 

--- a/NapDatabaseExport/MSSQLServerProvider.cs
+++ b/NapDatabaseExport/MSSQLServerProvider.cs
@@ -49,11 +49,11 @@ namespace NapDatabaseExport
             if (!string.IsNullOrEmpty (Server))
                 connectionString.DataSource = Server;
 
-            if (!string.IsNullOrEmpty(User))
+            if (!string.IsNullOrEmpty (User))
             {
                 connectionString.UserID = User;
 
-                if (!string.IsNullOrEmpty(Password))
+                if (!string.IsNullOrEmpty (Password))
                     connectionString.Password = Password;
             }
             else

--- a/NapDatabaseExport/MainForm.cs
+++ b/NapDatabaseExport/MainForm.cs
@@ -104,7 +104,7 @@ namespace NapDatabaseExport
                 }
             }
 
-            if (currentProvider.UsesUser) {
+            if (currentProvider.RequiresUser) {
                 if (string.IsNullOrWhiteSpace (txtUser.Text)) {
                     MessageBox.Show ("Моля, въведете потребител.", "Внимание!", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     txtUser.Focus ();
@@ -112,7 +112,7 @@ namespace NapDatabaseExport
                 }
             }
 
-            if (currentProvider.UsesPassword) {
+            if (currentProvider.RequiresPassword) {
                 if (string.IsNullOrWhiteSpace (txtPassword.Text)) {
                     MessageBox.Show ("Моля, въведете парола.", "Внимание!", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     txtPassword.Focus ();

--- a/NapDatabaseExport/SVExportProviderBase.cs
+++ b/NapDatabaseExport/SVExportProviderBase.cs
@@ -13,7 +13,7 @@ namespace NapDatabaseExport
 
         public override void StartExport (string filePath)
         {
-            writer = new StreamWriter(filePath, false, new UTF8Encoding(true));
+            writer = new StreamWriter (filePath, false, new UTF8Encoding (true));
         }
 
         public override void WriteColumnNames (string [] columns)

--- a/NapDatabaseExport/SVExportProviderBase.cs
+++ b/NapDatabaseExport/SVExportProviderBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace NapDatabaseExport
 {
@@ -12,7 +13,7 @@ namespace NapDatabaseExport
 
         public override void StartExport (string filePath)
         {
-            writer = File.CreateText (filePath);
+            writer = new StreamWriter(filePath, false, new UTF8Encoding(true));
         }
 
         public override void WriteColumnNames (string [] columns)


### PR DESCRIPTION
This small fix implements optional Integrated Security for SQL Server provider by convention when db user/pass are empty.

In order to allow both empty user/pass and non-empty user/pass a couple of new props are added to base `DatabaseProvider` -- `RequireUser` and `RequiredPass` and the client-side validation in `MainForm` is consulting these, not the `UsesUser` and `UserPassword` which are left to specify if user/pass entry is visible at all.

With previous design it was *not* possible to authenticate with a login without password because `UsesPassword` was treated as *not* allowing empty password (why?) in client-side validation.

The last commit 2af0b8cf1f325c9590b8da377bb872848ed13910 implements BOM for utf-8 files so that Excel can open generated CSVs with double click. Without BOM it badly chokes on utf-8 files, treating these as ACP encoded.