### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text eol=crlf
+
+*.dll binary


### PR DESCRIPTION
Without `.gitattributes` set the ZIP file download with sources on repo's home pages brings all files with linux style eol (\n) which might cause troubles when submitted to NRA etc.