### PR TITLE
Some sqlite fixes and more

### DIFF
--- a/NapDatabaseExport/ExportProvider.cs
+++ b/NapDatabaseExport/ExportProvider.cs
@@ -18,8 +18,8 @@
         {
             return new ExportProvider []
                 {
-                    new SemicolonSVExportProvider (),
-                    new CommaSVExportProvider ()
+                    new CommaSVExportProvider (),
+                    new SemicolonSVExportProvider ()
                 };
         }
     }

--- a/NapDatabaseExport/MainForm.cs
+++ b/NapDatabaseExport/MainForm.cs
@@ -19,7 +19,7 @@ namespace NapDatabaseExport
             cboExportType.DisplayMember = nameof (ExportProvider.ExportType);
             cboExportType.DataSource = dataExporters;
 
-            txtExportFolder.Text = Directory.GetCurrentDirectory();
+            txtExportFolder.Text = Directory.GetCurrentDirectory ();
 
             SetDatabaseEnabled (false);
             SetTablesEnabled (false);
@@ -230,8 +230,7 @@ namespace NapDatabaseExport
 
                 string table = string.Empty;
                 int tableRow = 0;
-                try
-                {
+                try {
                     foreach (string listTable in chlTables.CheckedItems)
                     {
                         table = listTable.Trim ();
@@ -250,7 +249,7 @@ namespace NapDatabaseExport
                                 continue;
                             }
 
-                            var columns = new string[reader.FieldCount];
+                            var columns = new string [reader.FieldCount];
                             for (int j = 0; j < reader.FieldCount; j++)
                                 columns[j] = reader.GetName (j);
 
@@ -261,7 +260,7 @@ namespace NapDatabaseExport
                             {
                                 for (int j = 0; j < reader.FieldCount; j++) {
                                     try {
-                                        row[j] = reader.GetValue(j);
+                                        row[j] = reader.GetValue (j);
                                     }
                                     catch (Exception) {
                                         Debug.WriteLine("Грешка при експорт на " + table + " на ред " + tableRow + " колона " + columns[j]);

--- a/NapDatabaseExport/MainForm.cs
+++ b/NapDatabaseExport/MainForm.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.Windows.Forms;
 
@@ -18,7 +19,7 @@ namespace NapDatabaseExport
             cboExportType.DisplayMember = nameof (ExportProvider.ExportType);
             cboExportType.DataSource = dataExporters;
 
-            txtExportFolder.Text = Environment.GetFolderPath (Environment.SpecialFolder.Desktop);
+            txtExportFolder.Text = Directory.GetCurrentDirectory();
 
             SetDatabaseEnabled (false);
             SetTablesEnabled (false);
@@ -227,10 +228,14 @@ namespace NapDatabaseExport
                 var exportProvider = (ExportProvider) cboExportType.SelectedItem;
                 var databaseProvider = (DatabaseProvider) cboDatabaseType.SelectedItem;
 
-                try {
+                string table = string.Empty;
+                int tableRow = 0;
+                try
+                {
                     foreach (string listTable in chlTables.CheckedItems)
                     {
-                        var table = listTable.Trim ();
+                        table = listTable.Trim ();
+                        tableRow = 0;
                         exportProvider.StartExport (Path.Combine(exportFolder,
                             table + exportProvider.DefaultFileExtension));
                         var commandText = databaseProvider.UsesQuoteTableNames
@@ -238,13 +243,14 @@ namespace NapDatabaseExport
                             : "SELECT * FROM " + table;
                         using (var reader = databaseProvider.ExecuteReader (commandText))
                         {
+                            tableRow++;
                             if (!reader.Read ())
                             {
                                 exportProvider.FinishExport ();
                                 continue;
                             }
 
-                            var columns = new string [reader.FieldCount];
+                            var columns = new string[reader.FieldCount];
                             for (int j = 0; j < reader.FieldCount; j++)
                                 columns[j] = reader.GetName (j);
 
@@ -253,9 +259,14 @@ namespace NapDatabaseExport
                             var row = new object [reader.FieldCount];
                             do
                             {
-                                for (int j = 0; j < reader.FieldCount; j++)
-                                    row[j] = reader.GetValue (j);
-
+                                for (int j = 0; j < reader.FieldCount; j++) {
+                                    try {
+                                        row[j] = reader.GetValue(j);
+                                    }
+                                    catch (Exception) {
+                                        Debug.WriteLine("Грешка при експорт на " + table + " на ред " + tableRow + " колона " + columns[j]);
+                                    }
+                                }
                                 exportProvider.WriteRow (row);
                             } while (reader.Read ());
                         }
@@ -263,9 +274,9 @@ namespace NapDatabaseExport
                         exportProvider.FinishExport ();
                     }
 
-                    MessageBox.Show ("Експорта на данни приключи успешно", "Успех", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    MessageBox.Show ("Експортът на данни приключи успешно", "Успех", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 } catch (Exception ex) {
-                    MessageBox.Show ("Грешка при експорт на данни: " + ex, "Внимание!", MessageBoxButtons.OK,MessageBoxIcon.Warning);
+                    MessageBox.Show ("Грешка при експорт на " + table + " на ред " + tableRow + ": " + ex, "Внимание!", MessageBoxButtons.OK,MessageBoxIcon.Warning);
                 }
             } finally {
                 Cursor.Current = Cursors.Default;

--- a/NapDatabaseExport/SQLiteProvider.cs
+++ b/NapDatabaseExport/SQLiteProvider.cs
@@ -76,7 +76,7 @@ namespace NapDatabaseExport
         {
             var tables = new List<string> ();
 
-            using (var dr = ExecuteReader ("SELECT name FROM sqlite_master WHERE type='table'"))
+            using (var dr = ExecuteReader ("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"))
                 while (dr.Read ())
                     tables.Add (dr.GetString (0));
 

--- a/NapDatabaseExport/SVExportProviderBase.cs
+++ b/NapDatabaseExport/SVExportProviderBase.cs
@@ -25,8 +25,8 @@ namespace NapDatabaseExport
         {
             writer.WriteLine (string.Join (Delimiter,
                 values.Select (v => v != null && v != DBNull.Value
-                                ? GetCellValue (v is byte[] ? "0x" + BitConverter.ToString((byte[]) v).Replace("-", "") : v.ToString ())
-                                : string.Empty)));
+                    ? GetCellValue (v is byte [] ? "0x" + BitConverter.ToString ((byte []) v).Replace ("-", "") : v.ToString ())
+                    : string.Empty)));
         }
 
         private string GetCellValue (string data)

--- a/NapDatabaseExport/SVExportProviderBase.cs
+++ b/NapDatabaseExport/SVExportProviderBase.cs
@@ -24,7 +24,9 @@ namespace NapDatabaseExport
         public override void WriteRow (object [] values)
         {
             writer.WriteLine (string.Join (Delimiter,
-                values.Select (v => v != null && v != DBNull.Value ? GetCellValue (v.ToString ()) : string.Empty)));
+                values.Select (v => v != null && v != DBNull.Value
+                                ? GetCellValue (v is byte[] ? "0x" + BitConverter.ToString((byte[]) v).Replace("-", "") : v.ToString ())
+                                : string.Empty)));
         }
 
         private string GetCellValue (string data)


### PR DESCRIPTION
The most important fix is the use of `BitConverter` on BLOBs (byte arrays) so that these are actually hex-dumped instead of output as "System.Byte[]" text by `ToString` or similar.

Also tables names from sqlite are ordered, default output folder is preset to `Directory.GetCurrentDirectory()` instead of user's desktop and output providers array is reordered so that CSV output is first and used by default (I'm not sure NRA will accept semi-colons delimited files at all).

I think the non-standard C# code formating is borked at some places once again as I had to re-edit it manually to fit space before bracket on function call but missed space before square brackets on array indexes.