### PR TITLE
Mark .docx files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text eol=crlf
 
 *.dll binary
+*.docx binary


### PR DESCRIPTION
This was missing when `Ръководство за инструмент с отворен код.docx` was commited in first place and now the file in the repo is corrupted.

To fix this issue best would be probably to reupload it *after* merging the PR.